### PR TITLE
remove max_threads config option

### DIFF
--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -32,7 +32,7 @@ ATTENTION_TYPE = Literal["auto", "normal", "xformers", "sliced", "torch-sdp"]
 ATTENTION_SLICE_SIZE = Literal["auto", "balanced", "max", 1, 2, 3, 4, 5, 6, 7, 8]
 LOG_FORMAT = Literal["plain", "color", "syslog", "legacy"]
 LOG_LEVEL = Literal["debug", "info", "warning", "error", "critical"]
-CONFIG_SCHEMA_VERSION = "4.0.3"
+CONFIG_SCHEMA_VERSION = "4.0.4"
 
 
 def get_default_ram_cache_size() -> float:
@@ -112,7 +112,6 @@ class InvokeAIAppConfig(BaseSettings):
         force_tiled_decode: Whether to enable tiled VAE decode (reduces memory consumption with some performance penalty).
         pil_compress_level: The compress_level setting of PIL.Image.save(), used for PNG encoding. All settings are lossless. 0 = no compression, 1 = fastest with slightly larger filesize, 9 = slowest with smallest filesize. 1 is typically the best setting.
         max_queue_size: Maximum number of items in the session queue.
-        max_threads: Maximum number of session queue execution threads. Autocalculated from number of GPUs if not set.
         clear_queue_on_startup: Empties session queue on startup.
         allow_nodes: List of nodes to allow. Omit to allow all.
         deny_nodes: List of nodes to deny. Omit to deny none.
@@ -186,7 +185,6 @@ class InvokeAIAppConfig(BaseSettings):
     force_tiled_decode:            bool = Field(default=False,              description="Whether to enable tiled VAE decode (reduces memory consumption with some performance penalty).")
     pil_compress_level:             int = Field(default=1,                  description="The compress_level setting of PIL.Image.save(), used for PNG encoding. All settings are lossless. 0 = no compression, 1 = fastest with slightly larger filesize, 9 = slowest with smallest filesize. 1 is typically the best setting.")
     max_queue_size:                 int = Field(default=10000, gt=0,        description="Maximum number of items in the session queue.")
-    max_threads:          Optional[int] = Field(default=None,               description="Maximum number of session queue execution threads. Autocalculated from number of GPUs if not set.")
     clear_queue_on_startup:        bool = Field(default=False,              description="Empties session queue on startup.")
 
     # NODES
@@ -448,6 +446,22 @@ def migrate_v4_0_2_to_4_0_3_config_dict(config_dict: dict[str, Any]) -> dict[str
     parsed_config_dict["schema_version"] = "4.0.3"
     return parsed_config_dict
 
+def migrate_v4_0_3_to_4_0_4_config_dict(config_dict: dict[str, Any]) -> dict[str, Any]:
+    """Migrate v4.0.3 config dictionary to a current config object.
+
+    Migrate MGPU-related config changes.
+
+    Args:
+        config_dict: A dictionary of settings from a v4.0.3 config file.
+
+    Returns:
+        An instance of `InvokeAIAppConfig` with the migrated settings.
+    """
+    parsed_config_dict: dict[str, Any] = copy.deepcopy(config_dict)
+    parsed_config_dict.pop("max_threads", None)
+    parsed_config_dict["schema_version"] = "4.0.4"
+    return parsed_config_dict
+
 # TO DO: replace this with a formal registration and migration system
 def load_and_migrate_config(config_path: Path) -> InvokeAIAppConfig:
     """Load and migrate a config file to the latest version.
@@ -478,6 +492,10 @@ def load_and_migrate_config(config_path: Path) -> InvokeAIAppConfig:
     if loaded_config_dict["schema_version"] == "4.0.2":
         migrated = True
         loaded_config_dict = migrate_v4_0_2_to_4_0_3_config_dict(loaded_config_dict)
+
+    if loaded_config_dict["schema_version"] == "4.0.3":
+        migrated = True
+        loaded_config_dict = migrate_v4_0_3_to_4_0_4_config_dict(loaded_config_dict)
 
     if migrated:
         shutil.copy(config_path, config_path.with_suffix(".yaml.bak"))

--- a/invokeai/app/services/config/config_default.py
+++ b/invokeai/app/services/config/config_default.py
@@ -446,6 +446,7 @@ def migrate_v4_0_2_to_4_0_3_config_dict(config_dict: dict[str, Any]) -> dict[str
     parsed_config_dict["schema_version"] = "4.0.3"
     return parsed_config_dict
 
+
 def migrate_v4_0_3_to_4_0_4_config_dict(config_dict: dict[str, Any]) -> dict[str, Any]:
     """Migrate v4.0.3 config dictionary to a current config object.
 
@@ -461,6 +462,7 @@ def migrate_v4_0_3_to_4_0_4_config_dict(config_dict: dict[str, Any]) -> dict[str
     parsed_config_dict.pop("max_threads", None)
     parsed_config_dict["schema_version"] = "4.0.4"
     return parsed_config_dict
+
 
 # TO DO: replace this with a formal registration and migration system
 def load_and_migrate_config(config_path: Path) -> InvokeAIAppConfig:

--- a/invokeai/app/services/model_manager/model_manager_default.py
+++ b/invokeai/app/services/model_manager/model_manager_default.py
@@ -7,15 +7,15 @@ from invokeai.app.services.config.config_default import InvokeAIAppConfig
 from invokeai.app.services.download.download_base import DownloadQueueServiceBase
 from invokeai.app.services.events.events_base import EventServiceBase
 from invokeai.app.services.invoker import Invoker
-from invokeai.backend.model_manager.load import ModelCache, ModelLoaderRegistry
-from invokeai.backend.util.logging import InvokeAILogger
-from invokeai.app.services.model_manager.model_manager_base import ModelManagerServiceBase
 from invokeai.app.services.model_install.model_install_base import ModelInstallServiceBase
 from invokeai.app.services.model_install.model_install_default import ModelInstallService
 from invokeai.app.services.model_load.model_load_base import ModelLoadServiceBase
 from invokeai.app.services.model_load.model_load_default import ModelLoadService
+from invokeai.app.services.model_manager.model_manager_base import ModelManagerServiceBase
 from invokeai.app.services.model_records.model_records_base import ModelRecordServiceBase
 from invokeai.backend.model_manager.load import ModelCache, ModelLoaderRegistry
+from invokeai.backend.util.logging import InvokeAILogger
+
 
 class ModelManagerService(ModelManagerServiceBase):
     """

--- a/invokeai/app/services/object_serializer/object_serializer_disk.py
+++ b/invokeai/app/services/object_serializer/object_serializer_disk.py
@@ -10,7 +10,6 @@ import torch
 from invokeai.app.services.object_serializer.object_serializer_base import ObjectSerializerBase
 from invokeai.app.services.object_serializer.object_serializer_common import ObjectNotFoundError
 from invokeai.app.util.misc import uuid_string
-from invokeai.backend.util.devices import TorchDevice
 
 if TYPE_CHECKING:
     from invokeai.app.services.invoker import Invoker

--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -356,9 +356,7 @@ class DefaultSessionProcessor(SessionProcessorBase):
             else None
         )
 
-        self._worker_thread_count = len(
-            TorchDevice.execution_devices()
-        )
+        self._worker_thread_count = len(TorchDevice.execution_devices())
 
         self._session_worker_queue: Queue[SessionQueueItem] = Queue()
 

--- a/invokeai/app/services/session_processor/session_processor_default.py
+++ b/invokeai/app/services/session_processor/session_processor_default.py
@@ -356,7 +356,7 @@ class DefaultSessionProcessor(SessionProcessorBase):
             else None
         )
 
-        self._worker_thread_count = self._invoker.services.configuration.max_threads or len(
+        self._worker_thread_count = len(
             TorchDevice.execution_devices()
         )
 

--- a/invokeai/backend/model_manager/config.py
+++ b/invokeai/backend/model_manager/config.py
@@ -38,7 +38,9 @@ from invokeai.backend.stable_diffusion.schedulers.schedulers import SCHEDULER_NA
 
 # ModelMixin is the base class for all diffusers and transformers models
 # RawModel is the InvokeAI wrapper class for ip_adapters, loras, textual_inversion and onnx runtime
-AnyModel = Union[ConfigMixin, ModelMixin, RawModel, torch.nn.Module, Dict[str, torch.Tensor], diffusers.DiffusionPipeline]
+AnyModel = Union[
+    ConfigMixin, ModelMixin, RawModel, torch.nn.Module, Dict[str, torch.Tensor], diffusers.DiffusionPipeline
+]
 
 
 class InvalidModelConfigException(Exception):

--- a/invokeai/backend/util/devices.py
+++ b/invokeai/backend/util/devices.py
@@ -2,7 +2,6 @@
 
 from typing import TYPE_CHECKING, Dict, Literal, Optional, Set, Union
 
-import threading
 import torch
 from deprecated import deprecated
 


### PR DESCRIPTION
## Summary

The `max_threads` option is confusing and liable to encourage footshot behavior. This PR removes it. The number of rendering threads is now always set to be equal to the number of execution devices indicated in the `devices` option (all devices if this option is not set).

<!--A description of the changes in this PR. Include the kind of change (fix, feature, docs, etc), the "why" and the "how". Screenshots or videos are useful for frontend changes.-->

## Related Issues / Discussions

<!--WHEN APPLICABLE: List any related issues or discussions on github or discord. If this PR closes an issue, please use the "Closes #1234" format, so that the issue will be automatically closed when the PR merges.-->

## QA Instructions

<!--WHEN APPLICABLE: Describe how you have tested the changes in this PR. Provide enough detail that a reviewer can reproduce your tests.-->

## Merge Plan

<!--WHEN APPLICABLE: Large PRs, or PRs that touch sensitive things like DB schemas, may need some care when merging. For example, a careful rebase by the change author, timing to not interfere with a pending release, or a message to contributors on discord after merging.-->

## Checklist

- [ ] _The PR has a short but descriptive title, suitable for a changelog_
- [ ] _Tests added / updated (if applicable)_
- [ ] _Documentation added / updated (if applicable)_
